### PR TITLE
Linux doesn't have $TMPDIR, default to /tmp if $TMPDIR is unset.

### DIFF
--- a/zen.sh
+++ b/zen.sh
@@ -9,13 +9,13 @@ LOG_FILE=~/.zen_log
 PLAY_INTERVAL_BELL=true
 
 function play {
-    LOCAL_FILE=$TMPDIR/${1}.mp3
-    if [ ! -f $LOCAL_FILE ]; then
+	LOCAL_FILE="${TMPDIR:-/tmp}/${1}.mp3"
+    if [ ! -f "$LOCAL_FILE" ]; then
         URL_VAR=${1}_URL
         URL=${!URL_VAR}
-        curl -s -o $LOCAL_FILE $URL
+        curl -s -o "$LOCAL_FILE" "$URL"
     fi
-    afplay $LOCAL_FILE &
+    afplay "$LOCAL_FILE" &
 }
 
 function print_time {

--- a/zen.sh
+++ b/zen.sh
@@ -7,21 +7,9 @@ INTERVAL_MARKER=+
 LOG_FILE=~/.zen_log
 
 PLAY_INTERVAL_BELL=true
-CACHE_BELLS=true
 
 function play {
-	if [ "$CACHE_BELLS" = "true" ]; then
-		case "$(uname -s)" in
-			Darwin*) LOCAL_DIR="$HOME/Library/Caches/zen.sh" ;;
-			*) LOCAL_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/zen.sh"
-		esac
-
-		test -d "$LOCAL_DIR" || mkdir "$LOCAL_DIR"
-		LOCAL_FILE="$LOCAL_DIR/${1}.mp3"
-	else
-		LOCAL_FILE="${TMPDIR:-/tmp}/${1}.mp3"
-	fi
-
+	LOCAL_FILE="${TMPDIR:-/tmp}/${1}.mp3"
     if [ ! -f "$LOCAL_FILE" ]; then
         URL_VAR=${1}_URL
         URL=${!URL_VAR}

--- a/zen.sh
+++ b/zen.sh
@@ -7,9 +7,21 @@ INTERVAL_MARKER=+
 LOG_FILE=~/.zen_log
 
 PLAY_INTERVAL_BELL=true
+CACHE_BELLS=true
 
 function play {
-	LOCAL_FILE="${TMPDIR:-/tmp}/${1}.mp3"
+	if [ "$CACHE_BELLS" = "true" ]; then
+		case "$(uname -s)" in
+			Darwin*) LOCAL_DIR="$HOME/Library/Caches/zen.sh" ;;
+			*) LOCAL_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/zen.sh"
+		esac
+
+		test -d "$LOCAL_DIR" || mkdir "$LOCAL_DIR"
+		LOCAL_FILE="$LOCAL_DIR/${1}.mp3"
+	else
+		LOCAL_FILE="${TMPDIR:-/tmp}/${1}.mp3"
+	fi
+
     if [ ! -f "$LOCAL_FILE" ]; then
         URL_VAR=${1}_URL
         URL=${!URL_VAR}


### PR DESCRIPTION
Default the path of the `$LOCAL_FILE` variable to `/tmp` if `$TMPDIR` isn't set. Most Linux environments don't set `$TMPDIR`, so the path for the bells to be downloaded to was `/`, which the script doesn't have write access to. 
Also quoted some of the file paths.